### PR TITLE
Open new tab as a "child" of the source tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "browserslist": [
     "Chrome >= 55",
-    "Firefox >= 52",
+    "Firefox >= 57",
     "FirefoxAndroid >= 57",
     "Opera >= 42"
   ],

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -212,7 +212,7 @@ async function searchEngine(
   const tabUrl = await getTabUrl(url, engineId, options);
 
   if (options.openNewTab) {
-    const tab = await createTab(tabUrl, tabIndex, tabActive);
+    const tab = await createTab(tabUrl, tabIndex, tabId, tabActive);
     tabId = tab.id;
   } else {
     await browser.tabs.update(tabId, {url: tabUrl});

--- a/src/utils/app.js
+++ b/src/utils/app.js
@@ -75,7 +75,7 @@ async function showContributePage(action = false) {
   if (action) {
     url = `${url}?action=${action}`;
   }
-  await createTab(url, activeTab.index + 1);
+  await createTab(url, activeTab.index + 1, activeTab.id);
 }
 
 export {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -2,10 +2,13 @@ import browser from 'webextension-polyfill';
 
 const getText = browser.i18n.getMessage;
 
-function createTab(url, index, active = true) {
+function createTab(url, index, openerTabId, active = true) {
   const props = {url: url, active: active};
   if (typeof index !== 'undefined') {
     props['index'] = index;
+  }
+  if (typeof openerTabId !== 'undefined') {
+    props['openerTabId'] = openerTabId;
   }
   return browser.tabs.create(props);
 }


### PR DESCRIPTION
This should fix #14.

The method `tabs.create()` accepts a parameter `openerTabId` to specify the opener tab. When it is specified Firefox (and maybe Chrome also) backs the focus of tabs to the opener when the new tab is closed, so this change improves user experience around tab operations. (Moreover, some other addons like https://addons.mozilla.org/firefox/addon/tree-style-tab/ may use the information to detect relation of tabs.)

How about this change?