### PR TITLE
Add mnemonic to context menu

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -9,6 +9,11 @@
     "description": "Description of the extension."
   },
 
+  "contextMenuLabel": {
+    "message": "Web &Archives",
+    "description": "Main context menu label."
+  },
+
   "engineName_google_short": {
     "message": "Google",
     "description": "Short name of the search engine."

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -109,7 +109,7 @@ async function createMenu(options) {
 
     createMenuItem({
       id: 'par-1',
-      title: getText('extensionName'),
+      title: getText('contextMenuLabel'),
       contexts
     });
 


### PR DESCRIPTION
Adds a mnemonic to the "Web A̲rchives" context menu item for easy keyboard access (ie right click and press <kbd>A</kbd> to see the engine list).

Note: I *think* this is right, but couldn't actually test it because the build process was broken for me and there's no documentation.