### PR TITLE
Add option to remove URL parameters before searching archives

### DIFF
--- a/src/action/App.vue
+++ b/src/action/App.vue
@@ -140,6 +140,14 @@
       </div>
     </transition>
 
+    <div class="remove-params-option" v-if="showRemoveParamsOption">
+      <vn-switch
+        :label="getText('actionLabel_removeUrlParams')"
+        v-model="removeUrlParams"
+        density="compact"
+      ></vn-switch>
+    </div>
+
     <vn-divider class="header-separator" :class="separatorClasses"></vn-divider>
 
     <div class="list-items-wrap" ref="items" @scroll="onListScroll">
@@ -192,6 +200,7 @@ import {
   Menu,
   MenuIconButton,
   Select,
+  Switch,
   TextField
 } from 'vueton';
 
@@ -224,6 +233,7 @@ export default {
     [Menu.name]: Menu,
     [MenuIconButton.name]: MenuIconButton,
     [Select.name]: Select,
+    [Switch.name]: Switch,
     [TextField.name]: TextField,
     [ResizeObserver.name]: ResizeObserver
   },
@@ -234,6 +244,7 @@ export default {
 
       searchModeAction: '',
       docUrl: '',
+      removeUrlParams: false,
       listItems: {
         ...getListItems(
           {
@@ -296,7 +307,8 @@ export default {
       openActionMenu: false,
 
       enableOpenCurrentDoc: false,
-      enableContributions
+      enableContributions,
+      globalRemoveUrlParams: false
     };
   },
 
@@ -309,6 +321,10 @@ export default {
 
     showSettings: function () {
       return this.searchModeAction === 'url';
+    },
+
+    showRemoveParamsOption: function () {
+      return !this.globalRemoveUrlParams;
     }
   },
 
@@ -329,7 +345,8 @@ export default {
       await browser.runtime.sendMessage({
         id: 'actionPopupSubmit',
         docUrl: this.docUrl,
-        engine
+        engine,
+        removeUrlParams: this.showRemoveParamsOption ? this.removeUrlParams : undefined
       });
 
       this.closeAction();
@@ -416,6 +433,7 @@ export default {
 
     removeDocUrl: function () {
       this.docUrl = '';
+      this.removeUrlParams = false;
     },
 
     focusDocUrlInput: function () {
@@ -573,6 +591,8 @@ export default {
         );
       }
 
+      this.globalRemoveUrlParams = options.removeUrlParams;
+
       this.setupPinnedButtons({maxPins: this.maxPinnedToolbarButtons});
 
       this.theme = await getAppTheme(options.appTheme);
@@ -698,6 +718,13 @@ body {
 .settings {
   padding-top: 8px;
   padding-bottom: 24px;
+}
+
+.remove-params-option {
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .settings-enter-active,

--- a/src/assets/locales/en/messages.json
+++ b/src/assets/locales/en/messages.json
@@ -366,6 +366,11 @@
     "description": "Title of the option."
   },
 
+  "optionTitle_removeUrlParams": {
+    "message": "Remove URL parameters before searching",
+    "description": "Title of the option."
+  },
+
   "optionTitle_appTheme": {
     "message": "Theme",
     "description": "Title of the option."
@@ -394,6 +399,11 @@
   "inputPlaceholder_docUrl": {
     "message": "Page URL",
     "description": "Placeholder of the input."
+  },
+
+  "actionLabel_removeUrlParams": {
+    "message": "Remove URL parameters",
+    "description": "Label for the remove URL parameters option in action popup."
   },
 
   "buttonLabel_contribute": {

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -124,6 +124,12 @@
             v-model="options.showEngineIcons"
           ></vn-switch>
         </div>
+        <div class="option">
+          <vn-switch
+            :label="getText('optionTitle_removeUrlParams')"
+            v-model="options.removeUrlParams"
+          ></vn-switch>
+        </div>
         <div class="option" v-if="enableContributions">
           <vn-switch
             :label="getText('optionTitle_showContribPage')"
@@ -224,7 +230,8 @@ export default {
         showEngineIcons: false,
         openCurrentDocContextMenu: false,
         appTheme: '',
-        showContribPage: false
+        showContribPage: false,
+        removeUrlParams: false
       }
     };
   },

--- a/src/storage/config.json
+++ b/src/storage/config.json
@@ -20,7 +20,8 @@
       "20240619180111_add_menuchangeevent",
       "20240928183956_remove_search_engines",
       "20241213110403_remove_bing",
-      "20251011182228_add_software_heritage"
+      "20251011182228_add_software_heritage",
+      "20251108143519_add_remove_url_params"
     ],
     "session": [
       "20240514122825_initial_version"

--- a/src/storage/revisions/local/20251108143519_add_remove_url_params.js
+++ b/src/storage/revisions/local/20251108143519_add_remove_url_params.js
@@ -1,0 +1,15 @@
+const message = 'Add removeUrlParams';
+
+const revision = '20251108143519_add_remove_url_params';
+
+async function upgrade() {
+  const changes = {};
+
+  changes.removeUrlParams = false;
+
+  changes.storageVersion = revision;
+  return browser.storage.local.set(changes);
+}
+
+export {message, revision, upgrade};
+

--- a/src/utils/app.js
+++ b/src/utils/app.js
@@ -684,6 +684,17 @@ function normalizeUrl(url) {
   return parsedUrl.toString();
 }
 
+function removeUrlParams(url) {
+  try {
+    const parsedUrl = new URL(url);
+    parsedUrl.search = '';
+    return parsedUrl.toString();
+  } catch (err) {
+    // If URL parsing fails, return original URL
+    return url;
+  }
+}
+
 async function addTabRevision({addedTabId, removedTabId} = {}) {
   return requestLock('tab_revisions', async () => {
     const {tabRevisions} = await storage.get('tabRevisions', {area: 'session'});
@@ -756,6 +767,7 @@ export {
   isMatchingUrlHost,
   validateUrl,
   normalizeUrl,
+  removeUrlParams,
   addTabRevision,
   getTabRevisions
 };

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -14,7 +14,8 @@ const optionKeys = [
   'showContribPage',
   'pinActionToolbarOpenCurrentDoc',
   'pinActionToolbarOptions',
-  'pinActionToolbarContribute'
+  'pinActionToolbarContribute',
+  'removeUrlParams'
 ];
 
 const searchUrl = browser.runtime.getURL('/src/search/index.html') + '?id={id}';


### PR DESCRIPTION
- Add global option 'removeUrlParams' in settings to remove query parameters from URLs before searching
- Add per-search option in action popup when global option is disabled
- Always show action popup when global option is disabled to allow access to per-search option
- Add storage migration for new option
- Add localization strings for new options

This project does not accept pull requests. Please use issues to report bugs or suggest new features.
