### PR TITLE
Update Chrome Web Store URL to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <p align="center">
   </br></br>
-  <a href="https://chrome.google.com/webstore/detail/web-archives/hkligngkgcpcolhcnkgccglchdafcnao">
+  <a href="https://chromewebstore.google.com/detail/web-archives/hkligngkgcpcolhcnkgccglchdafcnao">
     <picture>
       <source srcset="https://i.imgur.com/XBIE9pk.png" media="(prefers-color-scheme: dark)">
       <img height="58" src="https://i.imgur.com/oGxig2F.png" alt="Chrome Web Store"></picture></a>


### PR DESCRIPTION
Updates chrome.google.com/webstore to chromewebstore.google.com